### PR TITLE
CHK-839: Fix validation for 424 VEN code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Validation for VEN national destination code "424".
 
 ## [4.10.3] - 2021-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [4.10.4] - 2021-07-27
 ### Fixed
 - Validation for VEN national destination code "424".
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/phone",
   "description": "front.phone is a Javascript library that identifies, validates and formats phone numbers",
-  "version": "4.10.3",
+  "version": "4.10.4",
   "paths": [
     "/front.phone"
   ],

--- a/src/script/countries/VEN.coffee
+++ b/src/script/countries/VEN.coffee
@@ -12,7 +12,7 @@ class Venezuela
 		@countryName = "Venezuela"
 		@countryNameAbbr = "VEN"
 		@countryCode = '58'
-		@regex = /^(?:(?:\+|)58|)(?:0|)(?:(?:(?:2(?:12|3[45789]|4[0-9]|5[1-9]|6[0-9]|7[0-9]|8[1-9]|9[1-5])|(?:4(?:1[24-8]|26)))\d{7}))$/
+		@regex = /^(?:(?:\+|)58|)(?:0|)(?:(?:(?:2(?:12|3[45789]|4[0-9]|5[1-9]|6[0-9]|7[0-9]|8[1-9]|9[1-5])|(?:4(?:1[24-8]|2[46])))\d{7}))$/
 		@optionalTrunkPrefix = '0'
 		@nationalNumberSeparator = ' '
 		@nationalDestinationCode =


### PR DESCRIPTION
This PR fixes the regex to include the recently added national destionation code "424" as a valid phone number.
