### PR TITLE
add North American Numbering Plan to ndc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.10.5] - 2021-08-31
+
 - Add North American Numbering Plan for National Destination Code
 
 ## [4.10.4] - 2021-07-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add North American Numbering Plan for National Destination Code
+
 ## [4.10.4] - 2021-07-27
 ### Fixed
 - Validation for VEN national destination code "424".

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/phone",
   "description": "front.phone is a Javascript library that identifies, validates and formats phone numbers",
-  "version": "4.10.4",
+  "version": "4.10.5",
   "paths": [
     "/front.phone"
   ],

--- a/src/script/countries/NANP.coffee
+++ b/src/script/countries/NANP.coffee
@@ -11,7 +11,7 @@ class NANP
 		@countryName = "NANP"
 		@countryNameAbbr = ["USA", "CAN", "ASM", "GUM", "MNP", "PRI", "VIR"]
 		@countryCode = '1'
-		@regex = /^(?:(?:(?:\+|)(?:1|))|)(?:1|)(?:2(?:0[1-9]|1[02-9]|2[03-9]|3[1469]|4[089]|5[01-46]|6[0279]|7[02469]|8[139])|3(?:0[1-9]|1[02-9]|2[01-35-7]|3[0124679]|4[01367]|5[12]|6[013457]|8[056])|4(?:0[1-9]|1[02-9]|2[345]|3[0-24578]|4[023578]|5[08]|6[349]|7[0589]|8[04]|50[1-57-9])|5(?:0[1-9]|1[02-9]|20|3[0149]|4[018]|5[179]|6[1-47]|7[0-59]|8[012567])|6(?:0[01-9]|1[0234-9]|2[023689]|3[0169]|4[0167]|5[01679]|6[01279]|7[01289]|8[01249])|7(?:0[1-9]|1[02-9]|2[04-7]|3[01247]|4[037]|5[47]|6[02359]|7[02-589]|8[012567])|8(?:0[1-8]|1[0-9]|2[0568]|3[0-289]|4[03578]|5[046-9]|6[02-57]|7[0238])|9(?:0[1-9]|1[02-9]|2[0589]|3[0146-9]|4[01579]|5[12469]|7[0-3589]|8[04-69]))\d{7}$/
+		@regex = /^(?:(?:(?:\+|)(?:1|))|)(?:1|)(?:2(?:0[1-9]|1[02-9]|2[03-9]|3[1469]|4[089]|5[01-46]|6[0279]|7[02469]|8[139])|3(?:0[1-9]|1[02-9]|2[01-35-7]|3[0124679]|4[01367]|5[12]|6[013457]|8[056])|4(?:0[1-9]|1[02-9]|2[345]|3[0-24578]|4[023578]|5[08]|6[349]|7[0589]|8[04]|50[1-57-9])|5(?:0[1-9]|1[02-9]|20|3[0149]|4[018]|5[179]|6[1-47]|7[0-59]|8[012567])|6(?:0[01-9]|1[0234-9]|2[023689]|3[0169]|4[0167]|5[01679]|6[01279]|7[01289]|8[01249])|7(?:0[1-9]|1[02-9]|2[04-7]|3[01247]|4[037]|5[47]|6[02359]|7[02-589]|8[012567])|8(?:0[0-8]|1[0-9]|2[0568]|3[0-389]|4[03-578]|5[04-9]|6[02-7]|7[02378]|88)|9(?:0[1-9]|1[02-9]|2[0589]|3[0146-9]|4[01579]|5[12469]|7[0-3589]|8[04-69]))\d{7}$/
 		@optionalTrunkPrefix = '1'
 		@nationalNumberSeparator = ' '
 		@usaNationalDestinationCode =
@@ -42,7 +42,11 @@ class NANP
 			[
 				'340'
 			]
-		@nationalDestinationCode = @usaNationalDestinationCode.concat(@canadaNationalDestinationCode, @asmNationalDestinationCode, @gumNationalDestinationCode, @mnpNationalDestinationCode, @priNationalDestinationCode, @virNationalDestinationCode)
+		@northAmericaNumberingPlanDestinationCode = 
+			[
+				'800', '833', '844', '855', '866', '877', '888'
+			]
+		@nationalDestinationCode = @usaNationalDestinationCode.concat(@canadaNationalDestinationCode, @asmNationalDestinationCode, @gumNationalDestinationCode, @mnpNationalDestinationCode, @priNationalDestinationCode, @virNationalDestinationCode, @northAmericaNumberingPlanDestinationCode)
 
 	specialRules: (withoutCountryCode, withoutNDC, ndc) =>
 		if withoutNDC.length is 7


### PR DESCRIPTION
#### What is the purpose of this pull request?

In the United States of America, Canada, and other countries participating in the North American Numbering Plan, a toll-free telephone number has one of the area codes 800, 833,[1] 844, 855, 866, 877, and 888. See more here: https://en.wikipedia.org/wiki/Toll-free_telephone_numbers_in_the_North_American_Numbering_Plan

Therefore, this PR adds the numbers that were not included.


#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
