### PR TITLE
Deploy front.phone on Delorean

### DIFF
--- a/.vtex/deployment.json
+++ b/.vtex/deployment.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "front-phone",
+    "name": "front.phone",
     "description": "front.phone is a Javascript library that identifies, validates and formats phone numbers",
     "build": {
       "provider": "jenkins",

--- a/.vtex/deployment.json
+++ b/.vtex/deployment.json
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "front-phone",
+    "description": "front.phone is a Javascript library that identifies, validates and formats phone numbers",
+    "build": {
+      "provider": "jenkins",
+      "type": "frontend",
+      "parameters": {
+        "AWS_ACCOUNT_ID": "053131491888",
+        "AWS_REGION": "us-east-1",
+        "SLACK_CHANNEL": "checkout-ui-notifications"
+      }
+    }
+  }
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [4.15.0] - 2022-02-23
 ### Changed
 - Update deploy pipeline to use Jenkins.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update deploy pipeline to use Jenkins.
 
 ## [4.14.0] - 2022-02-17
 

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -88,7 +88,7 @@ module.exports = (grunt) ->
   tasks =
     # Building block tasks
     build: ['clean', 'webpack:main', 'copy:main', 'copy:dev', 'copy:pkg']
-    test: ['build', 'mochaTest']
+    test: ['mochaTest']
     # Deploy tasks
     dist: ['build', 'mochaTest', 'coffee:dist', 'copy:deploy'] # Dist
     publish: ['build', 'mochaTest', 'gh-pages'] # Publish to Github Pages

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -90,7 +90,7 @@ module.exports = (grunt) ->
     build: ['clean', 'webpack:main', 'copy:main', 'copy:dev', 'copy:pkg']
     test: ['build', 'mochaTest']
     # Deploy tasks
-    dist: ['build', 'mochaTest', 'coffee:dist'] # Dist
+    dist: ['build', 'mochaTest', 'coffee:dist', 'copy:deploy'] # Dist
     publish: ['build', 'mochaTest', 'gh-pages'] # Publish to Github Pages
     # Development tasks
     dev: ['nolr', 'build', 'mochaTest', 'watch']

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "front.phone",
   "description": "front.phone is a Javascript library that identifies, validates and formats phone numbers",
-  "version": "4.14.0",
+  "version": "4.15.0",
   "paths": [
     "/front.phone"
   ],

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "test": "grunt test",
     "testWatch": "mocha --watch spec/**/*-spec.coffee --compilers coffee:coffee-script/register",
-    "dist": "grunt dist",
+    "build": "grunt dist",
     "prepublishOnly": "grunt dist"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "front.phone",
   "description": "front.phone is a Javascript library that identifies, validates and formats phone numbers",
   "version": "4.14.0",
-  "private": true,
   "paths": [
     "/front.phone"
   ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "@vtex/phone",
+  "name": "front.phone",
   "description": "front.phone is a Javascript library that identifies, validates and formats phone numbers",
   "version": "4.14.0",
+  "private": true,
   "paths": [
     "/front.phone"
   ],


### PR DESCRIPTION
This PR is an attempt to update the deployment of this repository to use Delorean instead of `front.libs`.

This will greatly improve on the deploy routine for this package, because we will only need to release the version here and flip the version on Delorean to update it everywhere, instead of needing to create at least 3 PRs (one here, one on `front.libs`, and another on the app you need the update – e.g. `vcs.checkout-ui`).
