### PR TITLE
removing special character in Iraq phone rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Iraq phone rule, removing special character `+`.
+
 ## [4.15.0] - 2022-02-23
 ### Changed
 - Update deploy pipeline to use Jenkins.

--- a/spec/countries/IRQ-spec.coffee
+++ b/spec/countries/IRQ-spec.coffee
@@ -8,7 +8,7 @@ describe 'Iraq', ->
 
         it 'landline number', ->
             # Arrange
-            number = "+964 1234567890"
+            number = "964 1234567890"
 
             # Act
             result = Phone.getPhoneInternational(number)
@@ -18,7 +18,7 @@ describe 'Iraq', ->
             expect(result.countryNameAbbr).to.equal('IRQ')
 
         it  'mobile number', ->
-            number = "+964 1234567890"
+            number = "964 1234567890"
             result = Phone.getPhoneInternational(number)
             expect(result.valid).to.be.true
             expect(result.isMobile).to.be.true

--- a/src/script/countries/IRQ.coffee
+++ b/src/script/countries/IRQ.coffee
@@ -7,7 +7,7 @@ class Iraq
 		@countryName = "Iraq"
 		@countryNameAbbr = "IRQ"
 		@countryCode = '964'
-		@regex = /^(?:\+|)(?:964|)(?:0|)*\d{10}$/
+		@regex = /^(?:964|)(?:0|)*\d{10}$/
 		@optionalTrunkPrefix = '0'
 		@nationalNumberSeparator = ' '
 		@nationalDestinationCode = []


### PR DESCRIPTION
Removing `+` special character in Iraq phone rule, requested by Amal.