### PR TITLE
Fix FRA numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.17.4] - 2022-10-19
+
 ### Fixed
 - France ('FRA') country rules to save numbers with only one preceding zero.
 
@@ -325,9 +327,10 @@ The project is now available on npm, so you may now use it with Webpack and Reac
 - Improve Brazil's regex
 
 
-[Unreleased]: https://github.com/vtex/front.phone/compare/v4.17.3...HEAD
+[Unreleased]: https://github.com/vtex/front.phone/compare/v4.17.4...HEAD
 [4.15.1]: https://github.com/vtex/front.phone/compare/v4.15.0...v4.15.1
 
+[4.17.4]: https://github.com/vtex/front.phone/compare/v4.17.3...v4.17.4
 [4.17.3]: https://github.com/vtex/front.phone/compare/v4.17.2...v4.17.3
 [4.17.2]: https://github.com/vtex/front.phone/compare/v4.17.1...v4.17.2
 [4.17.1]: https://github.com/vtex/front.phone/compare/v4.17.0...v4.17.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- France ('FRA') country rules to save numbers with only one preceding zero.
+
 ## [4.17.3] - 2022-08-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "front.phone",
   "description": "front.phone is a Javascript library that identifies, validates and formats phone numbers",
-  "version": "4.17.3",
+  "version": "4.17.4",
   "paths": [
     "/front.phone"
   ],

--- a/spec/countries/FRA-spec.coffee
+++ b/spec/countries/FRA-spec.coffee
@@ -26,7 +26,7 @@ describe 'France', ->
 			result = Phone.format(phone, Phone.NATIONAL)
 
 			# Assert
-			expect(result).to.match(/1 87 87 87 87/)
+			expect(result).to.match(/01 87 87 87 87/)
 
 	describe 'Should get a', ->
 

--- a/src/script/countries/FRA.coffee
+++ b/src/script/countries/FRA.coffee
@@ -27,7 +27,7 @@ class France
 		if ndc in ['6', '7']
 			phone.isMobile = true
 			phone.nationalDestinationCode = ''
-			phone.number = withoutCountryCode
+			phone.number = ndc + withoutNDC
 		else
 			phone.isMobile = false
 
@@ -39,7 +39,7 @@ class France
 
 		switch format
 			when Phone.NATIONAL, Phone.LOCAL
-				return @splitNumber(fullNumber).join(separator)
+				return @splitNumber('0' + fullNumber).join(separator)
 			else
 				return "+" + phone.countryCode + " " + @splitNumber(fullNumber).join(separator)
 


### PR DESCRIPTION
Change France ('FRA') country rules to save numbers with only one preceding zero. Tracked by [LOC-8980](https://vtex-dev.atlassian.net/browse/LOC-8980).