### PR TITLE
Fix ROU country rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.17.6] - 2023-01-06
+
 
 ### Fixed
 - Romania ('ROU') country rules to remove extra characters.
@@ -339,9 +341,10 @@ The project is now available on npm, so you may now use it with Webpack and Reac
 - Improve Brazil's regex
 
 
-[Unreleased]: https://github.com/vtex/front.phone/compare/v4.17.5...HEAD
+[Unreleased]: https://github.com/vtex/front.phone/compare/v4.17.6...HEAD
 [4.15.1]: https://github.com/vtex/front.phone/compare/v4.15.0...v4.15.1
 
+[4.17.6]: https://github.com/vtex/front.phone/compare/v4.17.5...v4.17.6
 [4.17.5]: https://github.com/vtex/front.phone/compare/v4.17.4...v4.17.5
 [4.17.4]: https://github.com/vtex/front.phone/compare/v4.17.3...v4.17.4
 [4.17.3]: https://github.com/vtex/front.phone/compare/v4.17.2...v4.17.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Fixed
+- Romania ('ROU') country rules to remove extra characters.
+
 ## [4.17.5] - 2022-12-06
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "front.phone",
-  "version": "4.17.4",
+  "version": "4.17.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "front.phone",
-      "version": "4.17.4",
+      "version": "4.17.5",
       "license": "MIT",
       "devDependencies": {
         "angular": "1.3.14",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "front.phone",
   "description": "front.phone is a Javascript library that identifies, validates and formats phone numbers",
-  "version": "4.17.5",
+  "version": "4.17.6",
   "paths": [
     "/front.phone"
   ],

--- a/src/script/countries/ROU.coffee
+++ b/src/script/countries/ROU.coffee
@@ -14,6 +14,14 @@ class Romania
 
 
 	specialRules: (withoutCountryCode, withoutNDC, ndc) =>
+		if withoutCountryCode[0] is '0'
+			# Sometimes clients may type their phones with a leading zero
+			# we should strip that
+			withoutNDC = withoutCountryCode.slice(1)
+		
+		if withoutCountryCode.slice(0,2) is '40'
+			withoutNDC = withoutCountryCode.slice(2)
+
 		phone = new PhoneNumber(@countryNameAbbr, @countryCode, ndc, withoutNDC)
 	
 		if withoutCountryCode[0] in ['6','7']


### PR DESCRIPTION
Fix Romania ('ROU') country rules to remove extra characters. Tracked in task [LOC-9768](https://vtex-dev.atlassian.net/browse/LOC-9768).

[LOC-9768]: https://vtex-dev.atlassian.net/browse/LOC-9768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LOC-9768]: https://vtex-dev.atlassian.net/browse/LOC-9768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ