### PR TITLE
Fix AUS country rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.17.8] - 2023-03-01
+
 ### Fixed
 - Australia ('AUS') country rules to accept front 0 and more digits.
 
@@ -350,9 +352,10 @@ The project is now available on npm, so you may now use it with Webpack and Reac
 - Improve Brazil's regex
 
 
-[Unreleased]: https://github.com/vtex/front.phone/compare/v4.17.7...HEAD
+[Unreleased]: https://github.com/vtex/front.phone/compare/v4.17.8...HEAD
 [4.15.1]: https://github.com/vtex/front.phone/compare/v4.15.0...v4.15.1
 
+[4.17.8]: https://github.com/vtex/front.phone/compare/v4.17.7...v4.17.8
 [4.17.7]: https://github.com/vtex/front.phone/compare/v4.17.6...v4.17.7
 [4.17.6]: https://github.com/vtex/front.phone/compare/v4.17.5...v4.17.6
 [4.17.5]: https://github.com/vtex/front.phone/compare/v4.17.4...v4.17.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Australia ('AUS') country rules to accept front 0 and more digits.
+
 ## [4.17.7] - 2023-01-26
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "front.phone",
   "description": "front.phone is a Javascript library that identifies, validates and formats phone numbers",
-  "version": "4.17.7",
+  "version": "4.17.8",
   "paths": [
     "/front.phone"
   ],

--- a/spec/countries/AUS-spec.coffee
+++ b/spec/countries/AUS-spec.coffee
@@ -62,7 +62,7 @@ describe 'Australia', ->
 
         it 'validate an invalid number', ->
             # Arrange
-            number = "+61 2 22234 1234"
+            number = "+61 2 22234 12340"
 
             # Act
             result = Phone.validate(number, '61')

--- a/src/script/countries/AUS.coffee
+++ b/src/script/countries/AUS.coffee
@@ -7,7 +7,7 @@ class Australia
 		@countryName = "Australia"
 		@countryNameAbbr = "AUS"
 		@countryCode = '61'
-		@regex = /^(?:(?:(?:\+|)(?:61|)|))([1-5,7-8])[0-9]{8}$/
+		@regex = /^(?:(?:(?:\+|)(?:61|)(?:0|)|))([1-5,7-8])[0-9]{8,9}$/
 		@optionalTrunkPrefix = '0'
 		@nationalNumberSeparator = ' '
 		@nationalDestinationCode =


### PR DESCRIPTION
Fix Australia ('AUS') country rules to accept front 0 and more digits. Tracked in task [LOC-10072](https://vtex-dev.atlassian.net/browse/LOC-10072).
![LOC-10072-06](https://user-images.githubusercontent.com/26465317/222184188-acbc31aa-1353-43e8-a3f0-c7404c5c853a.png)
![LO
![LOC-10072-03](https://user-images.githubusercontent.com/26465317/222184435-b86788a9-f572-4c2c-9cad-059326bae7e4.png)
C-10072-05](https://user-images.githubusercontent.com/26465317/222184327-fa17bdf5-585a-48fa-96f4-07f8f8cdffb9.png)


[LOC-10072]: https://vtex-dev.atlassian.net/browse/LOC-10072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ