### PR TITLE
Fix Australia phone format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Australia ('AUS') country rules to keep front 0 when saving.
+
 ## [4.17.8] - 2023-03-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.17.9] - 2023-03-10
+
 ### Fixed
 - Australia ('AUS') country rules to keep front 0 when saving.
 
@@ -355,9 +357,10 @@ The project is now available on npm, so you may now use it with Webpack and Reac
 - Improve Brazil's regex
 
 
-[Unreleased]: https://github.com/vtex/front.phone/compare/v4.17.8...HEAD
+[Unreleased]: https://github.com/vtex/front.phone/compare/v4.17.9...HEAD
 [4.15.1]: https://github.com/vtex/front.phone/compare/v4.15.0...v4.15.1
 
+[4.17.9]: https://github.com/vtex/front.phone/compare/v4.17.8...v4.17.9
 [4.17.8]: https://github.com/vtex/front.phone/compare/v4.17.7...v4.17.8
 [4.17.7]: https://github.com/vtex/front.phone/compare/v4.17.6...v4.17.7
 [4.17.6]: https://github.com/vtex/front.phone/compare/v4.17.5...v4.17.6

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "front.phone",
   "description": "front.phone is a Javascript library that identifies, validates and formats phone numbers",
-  "version": "4.17.8",
+  "version": "4.17.9",
   "paths": [
     "/front.phone"
   ],

--- a/src/script/countries/AUS.coffee
+++ b/src/script/countries/AUS.coffee
@@ -26,6 +26,27 @@ class Australia
 
 		return [number]
 
+	format: (phone, format = Phone.NATIONAL) =>
+		resultString = ""
+		fullNumber = phone.nationalDestinationCode + phone.number
+		separator = @nationalNumberSeparator
+
+		switch format
+			when Phone.NATIONAL, Phone.LOCAL
+				if phone.nationalDestinationCode
+					resultString += '(0' + phone.nationalDestinationCode + ') '
+				return resultString + @splitNumber(phone.number).join(separator)
+			else
+				return "+" + phone.countryCode + " " + phone.nationalDestinationCode + " " + phone.number
+
+	splitNumber: (number) =>
+		if number.length is 11
+			return Phone.compact number.split(/(\d{2})(\d{3})(\d{3})(\d{3})/)
+		else if number.length is 9
+			return Phone.compact number.split(/(\d{3})(\d{3})(\d{3})/)
+
+		return [number]
+
 # register
 australia = new Australia()
 Phone.countries['61'] = australia

--- a/src/script/countries/AUS.coffee
+++ b/src/script/countries/AUS.coffee
@@ -40,10 +40,15 @@ class Australia
 				return "+" + phone.countryCode + " " + phone.nationalDestinationCode + " " + phone.number
 
 	splitNumber: (number) =>
-		if number.length is 11
-			return Phone.compact number.split(/(\d{2})(\d{3})(\d{3})(\d{3})/)
-		else if number.length is 9
-			return Phone.compact number.split(/(\d{3})(\d{3})(\d{3})/)
+		switch number.length
+			when 11 
+				return Phone.compact number.split(/(\d{2})(\d{3})(\d{3})(\d{3})/)
+			when 10 
+				return Phone.compact number.split(/(\d{2})(\d{4})(\d{4})/)
+			when 9 
+				return Phone.compact number.split(/(\d{3})(\d{3})(\d{3})/)
+			when 8
+				return Phone.compact number.split(/(\d{4})(\d{4})/)
 
 		return [number]
 


### PR DESCRIPTION
Fix Australia ('AUS') country rules to keep front 0 when saving. Tracked in task [LOC-10112](https://vtex-dev.atlassian.net/browse/LOC-10112).
![image](https://user-images.githubusercontent.com/26465317/224314309-ddb50225-638c-419c-bf8b-637057e9594b.png)
![image](https://user-images.githubusercontent.com/26465317/224314380-5ba528cc-3337-4348-97e6-9640eb86ae76.png)


[LOC-10112]: https://vtex-dev.atlassian.net/browse/LOC-10112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ