### PR TITLE
Fix NZL phone format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- New Zealand ('NZL') country rules to keep front 0 when saving.
+
 ## [4.17.9] - 2023-03-10
 
 ### Fixed

--- a/spec/countries/NZL-spec.coffee
+++ b/spec/countries/NZL-spec.coffee
@@ -58,7 +58,7 @@ describe 'New Zealand', ->
             result = Phone.countries['64'].splitNumber(number)
 
             # Assert
-            expect(result.length).to.equal(3)
+            expect(result.length).to.equal(2)
 
     describe 'Should not', ->
 
@@ -74,7 +74,7 @@ describe 'New Zealand', ->
 
         it 'validate an invalid number', ->
             # Arrange
-            number = "+64 6 7564 6528"
+            number = "+64 5 7564 6528"
 
             # Act
             result = Phone.validate(number, '64')

--- a/spec/countries/NZL-spec.coffee
+++ b/spec/countries/NZL-spec.coffee
@@ -46,7 +46,7 @@ describe 'New Zealand', ->
             result = Phone.format(phone, Phone.INTERNATIONAL)
 
             # Assert
-            expect(result).to.match(/\+64 2 10 248 3336/)
+            expect(result).to.match(/\+64 2 102483336/)
 
     describe 'Should split', ->
 

--- a/src/script/countries/NZL.coffee
+++ b/src/script/countries/NZL.coffee
@@ -7,7 +7,7 @@ class NewZealand
 		@countryName = "New Zealand"
 		@countryNameAbbr = "NZL"
 		@countryCode = '64'
-		@regex = /^(?:(?:(?:\+|)(?:64|)(?:0|)| ))(([2][0-9]{7,9})|([3,4,6,7,9][0-9]{7}))$/
+		@regex = /^(?:(?:(?:\+|)(?:64|)(?:0|)|))([2-4,6-7,9])[0-9]{7,9}$/
 		@optionalTrunkPrefix = '0'
 		@nationalNumberSeparator = ' '
 		@nationalDestinationCode =
@@ -16,16 +16,15 @@ class NewZealand
 	specialRules: (withoutCountryCode, withoutNDC, ndc) =>
 		phone = new PhoneNumber(@countryNameAbbr, @countryCode, ndc, withoutNDC)
 
-		# if withoutCountryCode[0] in ['2']
 		if ndc in ['2']
 			phone.isMobile = true
 			return phone
 		else return phone
 
-	splitNumber: (number) =>
-		return Phone.compact number.split(/(\d{1})(\d{4})(\d{4})/)
+	# splitNumber: (number) =>
+	# 	return Phone.compact number.split(/(\d{1})(\d{4})(\d{4})/)
 
-		return [number]
+	# 	return [number]
 
 	format: (phone, format = Phone.NATIONAL) =>
 		resultString = ""
@@ -42,14 +41,12 @@ class NewZealand
 
 	splitNumber: (number) =>
 		switch number.length
+			when 10 
+				return Phone.compact number.split(/(\d{2})(\d{4})(\d{4})/)
+			when 9 
+				return Phone.compact number.split(/(\d{3})(\d{3})(\d{3})/)
 			when 8
-				if number[0] in ['2']
-					return Phone.compact number.split(/(\d{2})(\d{3})(\d{3})/)
-				else return Phone.compact number.split(/(\d{1})(\d{3})(\d{4})/)
-			when 9
-				return Phone.compact number.split(/(\d{2})(\d{3})(\d{4})/)
-			when 10
-				return Phone.compact number.split(/(\d{3})(\d{3})(\d{4})/)
+				return Phone.compact number.split(/(\d{4})(\d{4})/)
 
 		return [number]
 

--- a/src/script/countries/NZL.coffee
+++ b/src/script/countries/NZL.coffee
@@ -7,7 +7,7 @@ class NewZealand
 		@countryName = "New Zealand"
 		@countryNameAbbr = "NZL"
 		@countryCode = '64'
-		@regex = /^(?:(?:(?:\+|)(?:64|)|))(([2][0-9]{7,9})|([3,4,6,7,9][0-9]{7}))$/
+		@regex = /^(?:(?:(?:\+|)(?:64|)(?:0|)| ))(([2][0-9]{7,9})|([3,4,6,7,9][0-9]{7}))$/
 		@optionalTrunkPrefix = '0'
 		@nationalNumberSeparator = ' '
 		@nationalDestinationCode =
@@ -16,10 +16,29 @@ class NewZealand
 	specialRules: (withoutCountryCode, withoutNDC, ndc) =>
 		phone = new PhoneNumber(@countryNameAbbr, @countryCode, ndc, withoutNDC)
 
-		if withoutCountryCode[0] in ['2']
+		# if withoutCountryCode[0] in ['2']
+		if ndc in ['2']
 			phone.isMobile = true
 			return phone
 		else return phone
+
+	splitNumber: (number) =>
+		return Phone.compact number.split(/(\d{1})(\d{4})(\d{4})/)
+
+		return [number]
+
+	format: (phone, format = Phone.NATIONAL) =>
+		resultString = ""
+		fullNumber = phone.nationalDestinationCode + phone.number
+		separator = @nationalNumberSeparator
+
+		switch format
+			when Phone.NATIONAL, Phone.LOCAL
+				if phone.nationalDestinationCode
+					resultString += '(0' + phone.nationalDestinationCode + ') '
+				return resultString + @splitNumber(phone.number).join(separator)
+			else
+				return "+" + phone.countryCode + " " + phone.nationalDestinationCode + " " + phone.number
 
 	splitNumber: (number) =>
 		switch number.length


### PR DESCRIPTION
Fix New Zealand ('NZL') phone format. Tracked in task [LOC-10137](https://vtex-dev.atlassian.net/browse/LOC-10137).

[LOC-10137]: https://vtex-dev.atlassian.net/browse/LOC-10137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ