### PR TITLE
Fix Indonesia regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Indonesia ('IDN') regex.
+
 ## [4.17.9] - 2023-03-10
 
 ### Fixed

--- a/src/script/countries/IDN.coffee
+++ b/src/script/countries/IDN.coffee
@@ -7,7 +7,7 @@ class Indonesia
 		@countryName = "Indonesia"
 		@countryNameAbbr = "IDN"
 		@countryCode = '62'
-		@regex = /^(?:\+62|\(0\d{2,3}\)|0)\s?(?:361|8[17]\s?\d?)?(?:[ -]?\d{3,4}){2,3}$/
+		@regex = /^\+?(|62)\s?([0-9]{2,3})\s?\-?([0-9]{3,4})\s?\-?([0-9]{4,7})$/
 		@optionalTrunkPrefix = '0'
 		@nationalNumberSeparator = ' '
 		@nationalDestinationCode =


### PR DESCRIPTION
Fix Indonesia ('IDN') regex. Tracked in task [LOC-10190](https://vtex-dev.atlassian.net/browse/LOC-10190).

[LOC-10190]: https://vtex-dev.atlassian.net/browse/LOC-10190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ