### PR TITLE
Fix rules to accept slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.17.10] - 2023-04-12
+
 ### Fixed
 - Phone rules to accept slash when entering a number
 
@@ -360,9 +362,10 @@ The project is now available on npm, so you may now use it with Webpack and Reac
 - Improve Brazil's regex
 
 
-[Unreleased]: https://github.com/vtex/front.phone/compare/v4.17.9...HEAD
+[Unreleased]: https://github.com/vtex/front.phone/compare/v4.17.10...HEAD
 [4.15.1]: https://github.com/vtex/front.phone/compare/v4.15.0...v4.15.1
 
+[4.17.10]: https://github.com/vtex/front.phone/compare/v4.17.9...v4.17.10
 [4.17.9]: https://github.com/vtex/front.phone/compare/v4.17.8...v4.17.9
 [4.17.8]: https://github.com/vtex/front.phone/compare/v4.17.7...v4.17.8
 [4.17.7]: https://github.com/vtex/front.phone/compare/v4.17.6...v4.17.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Phone rules to accept slash when entering a number
+
 ## [4.17.9] - 2023-03-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "front.phone",
   "description": "front.phone is a Javascript library that identifies, validates and formats phone numbers",
-  "version": "4.17.9",
+  "version": "4.17.10",
   "paths": [
     "/front.phone"
   ],

--- a/src/script/Phone.coffee
+++ b/src/script/Phone.coffee
@@ -59,7 +59,7 @@ class Phone
 
 	normalize: (number) =>
 		# Remove whitespaces, parenthesis, slashes, dots, plus sign and letters
-		return number.replace(/\ |\(|\)|\-|\.|[A-z]|\+/g, "")
+		return number.replace(/\/|\ |\(|\)|\-|\.|[A-z]|\+/g, "")
 
 	compact: (array) =>
 		newArray = []


### PR DESCRIPTION
Fix phone rules to accept slashes when entering a number. Tracked in task [LOC-10390](https://vtex-dev.atlassian.net/browse/LOC-10390).

[LOC-10390]: https://vtex-dev.atlassian.net/browse/LOC-10390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ