### PR TITLE
Changed Colombia phone rules to reflect recent changes in their numbering plan.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- COL phone rules to reflect numbering plan changes.
+
 ## [4.17.10] - 2023-04-12
 
 ### Fixed

--- a/spec/countries/COL-spec.coffee
+++ b/spec/countries/COL-spec.coffee
@@ -19,14 +19,14 @@ describe 'Colombia', ->
 
 		it 'in national format', ->
 			# Arrange
-			number = "5729898565"
+			number = "576029898565"
 			phone = Phone.getPhoneInternational(number)
 
 			# Act
 			result = Phone.format(phone, Phone.NATIONAL)
 
 			# Assert
-			expect(result).to.match(/\(2\) 989 8565/)
+			expect(result).to.match(/\(602\) 989 8565/)
 
 		it 'in national format mobile', ->
 			# Arrange
@@ -43,7 +43,7 @@ describe 'Colombia', ->
 
 		it 'land line number', ->
 			# Arrange
-			number = "+57 1 9898656"
+			number = "+57 601 9898656"
 
 			# Act
 			result = Phone.getPhoneInternational(number)
@@ -78,13 +78,13 @@ describe 'Colombia', ->
 
 		it 'land line number', ->
 			# Arrange
-			number = "8986565"
+			number = "6018986565"
 
 			# Act
 			result = Phone.countries['57'].splitNumber(number)
 
 			# Assert
-			expect(result.length).to.equal(2)
+			expect(result.length).to.equal(3)
 
 		it 'mobile number', ->
 			# Arrange
@@ -100,7 +100,7 @@ describe 'Colombia', ->
 
 		it 'land line number', ->
 			# Arrange
-			number = "+57 1 9898656"
+			number = "+57 601 9898656"
 
 			# Act
 			result = Phone.validate(number)

--- a/src/script/countries/COL.coffee
+++ b/src/script/countries/COL.coffee
@@ -5,30 +5,31 @@ PhoneNumber = require('../PhoneNumber')
 # For more info check:
 # https://www.numberingplans.com/?page=dialling&sub=areacodes
 # http://en.wikipedia.org/wiki/Telephone_numbers_in_Colombia
+# https://www.itu.int/oth/T020200002C/en
+
 class Colombia
 	constructor: ->
 		@countryName = "Colombia"
 		@countryNameAbbr = "COL"
 		@countryCode = '57'
-		@regex = /^(?:(?:\+|)57|)(?:0|)(?:(?:[12345678]\d{7})|(?:3\d{9}))$/
+		@regex = /^(?:(?:\+|)57|)(?:(?:[6][0][1245678]\d{7})|(?:3\d{9}))$/
 		@optionalTrunkPrefix = '0'
 		@nationalNumberSeparator = ' '
 		@nationalDestinationCode =
 			[
-				'3(\\d{2})', '1', '2', '3', '4', '5', '6', '7', '8'
+				'3(\\d{2})', '601', '602', '604', '605', '606', '607', '608'
 			]
 
 	specialRules: (withoutCountryCode, withoutNDC, ndc) =>
 		phone = new PhoneNumber(@countryNameAbbr, @countryCode, '', withoutNDC)
-		if withoutCountryCode.indexOf('3') is 0 and withoutCountryCode.length is 10
+		if withoutCountryCode.indexOf('3') is 0
 			phone.isMobile = true
 			phone.number = withoutCountryCode
 			phone.nationalDestinationCode = ''
 			return phone
 		else
-			if withoutNDC.length is 7
-				phone.nationalDestinationCode = ndc
-				return phone
+			phone.nationalDestinationCode = ndc
+			return phone
 
 	splitNumber: (number) =>
 		if number.length is 7


### PR DESCRIPTION
This PR changes Colombia phone rules and tests to reflect the [recent addition of '60' to the beginning of their area codes](https://www.cambiala.gov.co/).

A few valid numbers for testing: (604) 350 7050, (601) 424 2400, 305 482 9046, 305 261 5442.