### PR TITLE
Fixed CHL phone rules to reflect numbering plan changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- CHL phone rules to reflect numbering plan changes.
+
 ## [4.17.10] - 2023-04-12
 
 ### Fixed

--- a/spec/countries/CHL-spec.coffee
+++ b/spec/countries/CHL-spec.coffee
@@ -45,11 +45,11 @@ describe 'Chile', ->
 			result = Phone.countries['56'].splitNumber(number)
 
 			# Assert
-			expect(result.length).to.equal(2)
+			expect(result.length).to.equal(3)
 
-		it 'number with 8 digits', ->
+		it 'number with 9 digits', ->
 			# Arrange
-			number = "98986565"
+			number = "998986565"
 
 	describe 'Should validate a', ->
 
@@ -62,10 +62,10 @@ describe 'Chile', ->
 			# Assert
 			expect(result).to.be.true
 
-		it 'number with destination national code 2', ->
+		it 'number starting with 2', ->
 			# Arrange
 			number = "+56 2 98986565"
 
-		it 'number with destination national code 5', ->
+		it 'number starting with 5', ->
 			# Arrange
 			number = "+56 5 89898656"

--- a/spec/countries/CHL-spec.coffee
+++ b/spec/countries/CHL-spec.coffee
@@ -6,7 +6,7 @@ describe 'Chile', ->
 
 	describe 'Should format a number', ->
 
-		it 'in national format mobile', ->
+		it 'in national format', ->
 			# Arrange
 			number = "56998986565"
 			phone = Phone.getPhoneInternational(number)
@@ -32,21 +32,9 @@ describe 'Chile', ->
 			# Arrange
 			number = "+56 2 98986565"
 
-		it 'number with 7 digits', ->
+		it 'number with destination national code 5', ->
 			# Arrange
-			number = "+56 35 9898656"
-
-		it 'number with 6 digits', ->
-			# Arrange
-			number = "+56 35 989865"
-
-		it 'number with destination national code 58', ->
-			# Arrange
-			number = "+56 58 9898656"
-
-		it 'mobile number', ->
-			# Arrange
-			number = "+56 9 98986565"
+			number = "+56 5 89898656"
 
 	describe 'Should split', ->
 
@@ -63,14 +51,6 @@ describe 'Chile', ->
 			# Arrange
 			number = "98986565"
 
-		it 'number with 7 digits', ->
-			# Arrange
-			number = "8986565"
-
-		it 'number with 6 digits', ->
-			# Arrange
-			number = "986565"
-
 	describe 'Should validate a', ->
 
 		number = ''
@@ -86,18 +66,6 @@ describe 'Chile', ->
 			# Arrange
 			number = "+56 2 98986565"
 
-		it 'number with 7 digits', ->
+		it 'number with destination national code 5', ->
 			# Arrange
-			number = "+56 35 9898656"
-
-		it 'number with 6 digits', ->
-			# Arrange
-			number = "+56 35 989865"
-
-		it 'number with destination national code 58', ->
-			# Arrange
-			number = "+56 58 9898656"
-
-		it 'mobile number', ->
-			# Arrange
-			number = "+56 9 98986565"
+			number = "+56 5 89898656"

--- a/src/script/countries/CHL.coffee
+++ b/src/script/countries/CHL.coffee
@@ -5,7 +5,7 @@ PhoneNumber = require('../PhoneNumber')
 # For more info check:
 # https://www.numberingplans.com/?page=dialling&sub=areacodes
 # http://www.howtocallabroad.com/chile/
-# (1) http://www.cambionumeracion.cl/?page_id=4
+# https://www.itu.int/oth/T020200002A/en
 class Chile
 	constructor: ->
 		@countryName = "Chile"
@@ -14,18 +14,16 @@ class Chile
 		@regex = /^(?:(?:\+|)56|)([2-9])\d{8}$/
 		@optionalTrunkPrefix = '0'
 		@nationalNumberSeparator = ' '
-		@nationalDestinationCode =
-			[
-				'2','3','4','5','6','7','8','9'
-			]
+		@nationalDestinationCode = []
 
 	specialRules: (withoutCountryCode, withoutNDC, ndc) =>
 		phone = new PhoneNumber(@countryNameAbbr, @countryCode, ndc, withoutNDC)
+		phone.number = withoutCountryCode
+		phone.nationalDestinationCode = ''
 		return phone
 
 	splitNumber: (number) =>
 		return Phone.compact number.split(/(\d{1})(\d{4})(\d{4})/)
-		return [number]
 
 # register
 chile = new Chile()

--- a/src/script/countries/CHL.coffee
+++ b/src/script/countries/CHL.coffee
@@ -11,42 +11,20 @@ class Chile
 		@countryName = "Chile"
 		@countryNameAbbr = "CHL"
 		@countryCode = '56'
-		@regex = /^(?:(?:\+|)56|)(?:0|)(?:(?:(?:2|9)\d{8})|(?:58\d{7})|(?:(?:3[2345]|4[1235]|5[12357]|6[134578]|7[1235])\d{6,7}))$/
+		@regex = /^(?:(?:\+|)56|)([2-9])\d{8}$/
 		@optionalTrunkPrefix = '0'
 		@nationalNumberSeparator = ' '
 		@nationalDestinationCode =
 			[
-				'2','32','33','34','35','41','42','43','45','51','52','53','55','57','58','61','63','64','65','67','68','71','72','73','75', '9' # 9 is mobile
+				'2','3','4','5','6','7','8','9'
 			]
 
 	specialRules: (withoutCountryCode, withoutNDC, ndc) =>
 		phone = new PhoneNumber(@countryNameAbbr, @countryCode, ndc, withoutNDC)
-		switch ndc
-			when '2'
-				if withoutNDC.length is 8 then return phone
-			when '9'
-				if withoutNDC.length is 8
-					phone.isMobile = true
-					phone.nationalDestinationCode = ''
-					phone.number = withoutCountryCode
-					return phone
-			when '58'
-				if withoutNDC.length is 7 then return phone
-			else
-			# Should be updated based on link (1)
-				if withoutNDC.length is 6 or withoutNDC.length is 7 then return phone
+		return phone
 
 	splitNumber: (number) =>
-		switch number.length
-			when 9
-				return Phone.compact number.split(/(\d{1})(\d{4})(\d{4})/)
-			when 8
-				return Phone.compact number.split(/(\d{4})(\d{4})/)
-			when 7
-				return Phone.compact number.split(/(\d{3})(\d{4})/)
-			when 6
-				return Phone.compact number.split(/(\d{2})(\d{4})/)
-
+		return Phone.compact number.split(/(\d{1})(\d{4})(\d{4})/)
 		return [number]
 
 # register


### PR DESCRIPTION
The [numbering plan changes carried out between 2012 and 2013](https://en.wikipedia.org/wiki/Telephone_numbers_in_Chile#Transition_to_area_code_deprecation) in CHL were never fully reflected in front.phone.
Also, any identification of mobile numbers was removed because [Chile has full portability](https://en.wikipedia.org/wiki/Telephone_numbers_in_Chile#Total_number_portability).

A few valid numbers for testing: 2 3275 8888, 2 2498 1800, 2 2799 9900, 269040000.