### PR TITLE
CHK-2504: Fix NZL phone format and validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.18.0] - 2023-05-24
+
 ### Changed
 - NZL phone number validation and rules.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- NZL phone number validation and rules.
+
 ## [4.17.11] - 2023-05-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "front.phone",
   "description": "front.phone is a Javascript library that identifies, validates and formats phone numbers",
-  "version": "4.17.11",
+  "version": "4.18.0",
   "paths": [
     "/front.phone"
   ],

--- a/spec/countries/NZL-spec.coffee
+++ b/spec/countries/NZL-spec.coffee
@@ -46,7 +46,7 @@ describe 'New Zealand', ->
             result = Phone.format(phone, Phone.INTERNATIONAL)
 
             # Assert
-            expect(result).to.match(/\+64 2 10 248 3336/)
+            expect(result).to.match(/\(02\) 102483336/)
 
     describe 'Should split', ->
 
@@ -58,7 +58,7 @@ describe 'New Zealand', ->
             result = Phone.countries['64'].splitNumber(number)
 
             # Assert
-            expect(result.length).to.equal(3)
+            expect(result.length).to.equal(1)
 
     describe 'Should not', ->
 

--- a/src/script/countries/NZL.coffee
+++ b/src/script/countries/NZL.coffee
@@ -7,7 +7,7 @@ class NewZealand
 		@countryName = "New Zealand"
 		@countryNameAbbr = "NZL"
 		@countryCode = '64'
-		@regex = /^(?:(?:(?:\+|)(?:64|)|))(([2][0-9]{7,9})|([3,4,6,7,9][0-9]{7}))$/
+		@regex = /^(?:(?:(?:\+|)(?:64|)|))(?:0|)(([2][0-9]{7,9})|([3,4,6,7,9][0-9]{7}))$/
 		@optionalTrunkPrefix = '0'
 		@nationalNumberSeparator = ' '
 		@nationalDestinationCode =

--- a/src/script/countries/NZL.coffee
+++ b/src/script/countries/NZL.coffee
@@ -7,32 +7,34 @@ class NewZealand
 		@countryName = "New Zealand"
 		@countryNameAbbr = "NZL"
 		@countryCode = '64'
-		@regex = /^(?:(?:(?:\+|)(?:64|)|))(?:0|)(([2][0-9]{7,9})|([3,4,6,7,9][0-9]{7}))$/
+		@regex = /^(?:(?:(?:\+|)(?:64|)|))(?:0|)(?:(?:[2][0-9]{7,9})|(?:[3,4,6,7,9][0-9]{7}))$/
 		@optionalTrunkPrefix = '0'
 		@nationalNumberSeparator = ' '
 		@nationalDestinationCode =
 			["2","3","4","6","7","9"]
+		@internationalFormatRegex = /^((?:\+|)(64))(\d{0,10})$/
 	
 	specialRules: (withoutCountryCode, withoutNDC, ndc) =>
 		phone = new PhoneNumber(@countryNameAbbr, @countryCode, ndc, withoutNDC)
-
+		isInternationalFormat = @internationalFormatRegex.test(withoutCountryCode)
+		
+		if isInternationalFormat
+			countryCodeRegex = new RegExp "^"+@countryCode
+			withoutCountryCode = withoutCountryCode.replace(countryCodeRegex, "")
+			ndc = withoutCountryCode[0]
+			phone = new PhoneNumber(@countryNameAbbr, @countryCode, ndc, withoutCountryCode.substr 1)
+			
 		if withoutCountryCode[0] in ['2']
 			phone.isMobile = true
 			return phone
 		else return phone
 
-	splitNumber: (number) =>
-		switch number.length
-			when 8
-				if number[0] in ['2']
-					return Phone.compact number.split(/(\d{2})(\d{3})(\d{3})/)
-				else return Phone.compact number.split(/(\d{1})(\d{3})(\d{4})/)
-			when 9
-				return Phone.compact number.split(/(\d{2})(\d{3})(\d{4})/)
-			when 10
-				return Phone.compact number.split(/(\d{3})(\d{3})(\d{4})/)
+	format: (phone, format) =>
+		return "(" + @optionalTrunkPrefix + phone.nationalDestinationCode + ") " + phone.number
 
+	splitNumber: (number) =>
 		return [number]
+
 
 # register
 newzealand = new NewZealand()

--- a/src/script/countries/NZL.coffee
+++ b/src/script/countries/NZL.coffee
@@ -35,7 +35,6 @@ class NewZealand
 	splitNumber: (number) =>
 		return [number]
 
-
 # register
 newzealand = new NewZealand()
 Phone.countries['64'] = newzealand


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR changes the NZL phone number validation rules. Now, every NZL number will be saved in a specific format.

You can check more details at: https://vtex-dev.atlassian.net/browse/LOC-10137

#### How should this be manually tested?

- [Add items to cart](http://vineonline.vtexcommercebeta.com.br/checkout/cart/add/?sku=1407&qty=1&seller=1&sc=1)
- Move forward to the Profile step
- If an user types `02123456789` as the phone number and proceeds to the next step, the number should be shown as `(02) 123456789`
- Similarly, if an user types `64 2 123456788`, it should be show as `(02) 123456788`