### PR TITLE
CHK-2504: Fix AUS phone validation and formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- AUS phone number validation and formatting.
+- NZL phone numbers beginning with country code and followed by zero.
+
 ## [4.18.0] - 2023-05-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.19.0] - 2023-05-25
+
 ### Fixed
 - AUS phone number validation and formatting.
 - NZL phone numbers beginning with country code and followed by zero.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "front.phone",
   "description": "front.phone is a Javascript library that identifies, validates and formats phone numbers",
-  "version": "4.18.0",
+  "version": "4.19.0",
   "paths": [
     "/front.phone"
   ],

--- a/spec/countries/AUS-spec.coffee
+++ b/spec/countries/AUS-spec.coffee
@@ -23,9 +23,9 @@ describe 'Australia', ->
             expect(result.valid).to.be.true
             expect(result.isMobile).to.be.true 
 
-    describe 'Should format a number', ->
+    describe 'Should format', ->
 
-        it 'in international format', ->
+        it 'a number in international format', ->
             # Arrange
             number = "61298789402"
             phone = Phone.getPhoneInternational(number)
@@ -34,7 +34,29 @@ describe 'Australia', ->
             result = Phone.format(phone, Phone.INTERNATIONAL)
 
             # Assert
-            expect(result).to.match(/\+61 2 98789402/)
+            expect(result).to.match(/\(02\) 9878 9402/)
+
+        it 'a mobile number in international format', ->
+            # Arrange
+            number = "+610498789402"
+            phone = Phone.getPhoneInternational(number)
+
+            # Act
+            result = Phone.format(phone, Phone.INTERNATIONAL)
+
+            # Assert
+            expect(result).to.match(/0498 789 402/)
+        
+        it 'a mobile number in national format', ->
+            # Arrange
+            number = "0411884057"
+            phone = Phone.getPhoneNational(number, '61', '4')
+
+            # Act
+            result = Phone.format(phone, Phone.NATIONAL)
+
+            # Assert
+            expect(result).to.match(/0411 884 057/)
 
     describe 'Should split', ->
 

--- a/src/script/countries/NZL.coffee
+++ b/src/script/countries/NZL.coffee
@@ -12,14 +12,14 @@ class NewZealand
 		@nationalNumberSeparator = ' '
 		@nationalDestinationCode =
 			["2","3","4","6","7","9"]
-		@internationalFormatRegex = /^((?:\+|)(64))(\d{0,10})$/
+		@internationalFormatRegex = /^((?:\+|)(64)(?:0|))(\d{0,10})$/
 	
 	specialRules: (withoutCountryCode, withoutNDC, ndc) =>
 		phone = new PhoneNumber(@countryNameAbbr, @countryCode, ndc, withoutNDC)
 		isInternationalFormat = @internationalFormatRegex.test(withoutCountryCode)
 		
 		if isInternationalFormat
-			countryCodeRegex = new RegExp "^"+@countryCode
+			countryCodeRegex = new RegExp "^"+@countryCode+'('+@optionalTrunkPrefix+'|)'
 			withoutCountryCode = withoutCountryCode.replace(countryCodeRegex, "")
 			ndc = withoutCountryCode[0]
 			phone = new PhoneNumber(@countryNameAbbr, @countryCode, ndc, withoutCountryCode.substr 1)


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, the aim of this PR is to adjust `AUS` phone numbers validation and formatting. 
We should format the numbers according to its type: mobile or landline.

For numbers beginning with 04 (meaning it is a mobile numbers), we should format it like this: `XXXX  XXX  XXX`
Other than that, the numbers should have the following format: `(XX)  XXXX  XXXX`

More details at: https://vtex-dev.atlassian.net/browse/LOC-10264

#### How should this be manually tested?

- [Add items to cart](http://averee.vtexcommercebeta.com.br/checkout/cart/add/?sku=1323&qty=1&seller=1&sc=1)
- Move forward to the Profile step
- Type `0298445422` as the phone number. Proceed to the Shipping step and ensure that the phone number will be shown as `(02) 9844 5422`

- Another test is to use `0411884057` as the phone number. Proceed to Shipping and ensure that the phone number will be shown as `0411 884 057`