### PR TITLE
chore: add pull_request trigger for SonarQube PR decoration

### DIFF
--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -13,8 +13,11 @@
       runtime:
         architecture: amd64
       when:
+      - event: pull_request
+        source: branch
       - event: push
         source: branch
+        regex: main
     - name: build-node-app-and-upload-artifacts-v1
       notifications:
         slack:


### PR DESCRIPTION
## Summary

- Add `pull_request` event trigger to the `node-ci-v2` pipeline so SonarQube analysis runs on pull requests and can post quality gate results as PR comments.
- Scope the existing `push` trigger to the `main` branch only, avoiding redundant CI runs on feature branches.

## Test plan

- [ ] Verify the `node-ci-v2` pipeline runs on new pull requests.
- [ ] Confirm SonarQube posts quality gate results as PR comments.
- [ ] Confirm the pipeline still runs on pushes to `main`.